### PR TITLE
Added feature: Option to update Hardcover page/status when closing a book.

### DIFF
--- a/hardcover/lib/constants/settings.lua
+++ b/hardcover/lib/constants/settings.lua
@@ -13,6 +13,7 @@ local Settings = {
   TRACK = {
     FREQUENCY = "frequency",
     PROGRESS = "progress",
+    CLOSE = "close",
   },
   USER_ID = "user_id",
 }

--- a/hardcover/lib/hardcover_settings.lua
+++ b/hardcover/lib/hardcover_settings.lua
@@ -186,6 +186,10 @@ function HardcoverSettings:trackByProgress()
   return self.settings:readSetting(SETTING.TRACK_METHOD) == SETTING.TRACK.PROGRESS
 end
 
+function HardcoverSettings:trackByClose()
+  return self.settings:readSetting(SETTING.TRACK_METHOD) == SETTING.TRACK.CLOSE
+end
+
 function HardcoverSettings:changeTrackPercentageInterval(percent)
   self:updateSetting(SETTING.TRACK_PERCENTAGE, percent)
 end

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -548,6 +548,16 @@ function HardcoverMenu:getTrackingSubMenuItems()
       end,
       keep_menu_open = true
     },
+    {
+      text = "Update on document close",
+      radio = true,
+      checked_func = function()
+        return self.settings:readSetting(SETTING.TRACK_METHOD) == SETTING.TRACK.CLOSE
+      end,
+      callback = function()
+        self.settings:setTrackMethod(SETTING.TRACK.CLOSE)
+      end
+    },
   }
 end
 

--- a/main.lua
+++ b/main.lua
@@ -347,7 +347,6 @@ function HardcoverApp:pageUpdateEvent(page)
       self:_handlePageUpdate(self.ui.document.file, mapped_page)
     end
   elseif self.settings:trackByClose() then
-    logger.warn("HARDCOVER trackByClose enabled, setting page_update_pending and pending_page_update")
     self.page_update_pending = true
     self.state.pending_page_update = true
   end

--- a/main.lua
+++ b/main.lua
@@ -259,9 +259,6 @@ function HardcoverApp:onSettingsChanged(field, change, original_value)
 end
 
 function HardcoverApp:_handlePageUpdate(filename, mapped_page, immediate, callback)
-  --logger.warn("HARDCOVER: Throttled page update", mapped_page)
-  self.page_update_pending = false
-
   if not self:syncFileUpdates(filename) then
     return
   end
@@ -275,6 +272,8 @@ function HardcoverApp:_handlePageUpdate(filename, mapped_page, immediate, callba
   if not current_read then
     return
   end
+
+  self.page_update_pending = false
 
   local immediate_update = function()
     self.wifi:withWifi(function()
@@ -347,6 +346,8 @@ function HardcoverApp:pageUpdateEvent(page)
     if last_compare ~= current_compare then
       self:_handlePageUpdate(self.ui.document.file, mapped_page)
     end
+  elseif self.settings:trackByClose() then
+    self.page_update_pending = true
   end
 end
 
@@ -384,18 +385,18 @@ function HardcoverApp:cancelPendingUpdates()
   self.page_update_pending = false
 end
 
-function HardcoverApp:onDocumentClose()
+function HardcoverApp:onCloseDocument()
   UIManager:unschedule(self.startCacheRead)
+
+  if self.page_update_pending then
+    self:updatePageNow()
+  end
 
   self:cancelPendingUpdates()
   self.state.read_cache_started = false
 
   if not self.state.book_status.id and not self.settings:syncEnabled() then
     return
-  end
-
-  if self.page_update_pending then
-    self:updatePageNow()
   end
 
   self.process_page_turns = false

--- a/main.lua
+++ b/main.lua
@@ -347,7 +347,9 @@ function HardcoverApp:pageUpdateEvent(page)
       self:_handlePageUpdate(self.ui.document.file, mapped_page)
     end
   elseif self.settings:trackByClose() then
+    logger.warn("HARDCOVER trackByClose enabled, setting page_update_pending and pending_page_update")
     self.page_update_pending = true
+    self.state.pending_page_update = true
   end
 end
 
@@ -388,6 +390,10 @@ end
 function HardcoverApp:onCloseDocument()
   UIManager:unschedule(self.startCacheRead)
 
+  if not self.state.book_status.id and not self.settings:syncEnabled() then
+    return
+  end
+
   if self.page_update_pending then
     self:updatePageNow()
   end
@@ -395,17 +401,20 @@ function HardcoverApp:onCloseDocument()
   self:cancelPendingUpdates()
   self.state.read_cache_started = false
 
-  if not self.state.book_status.id and not self.settings:syncEnabled() then
-    return
-  end
-
   self.process_page_turns = false
   self.page_update_pending = false
   self.state.book_status = {}
   self.state.page_map = nil
+  self.state.pending_page_update = nil
 end
 
 function HardcoverApp:onSuspend()
+  
+  if self.state.pending_page_update then
+    self:updatePageNow()
+    self.state.pending_page_update = nil
+  end
+
   self:cancelPendingUpdates()
 
   Scheduler:clear()


### PR DESCRIPTION
--- Option in settings to enable/disable this feature.
--- Changed OnDocumentClose() to OnCloseDocument() to trigger update outside of the reader UI.
--- reordered a couple update events to receive needed true flag on page_update_pending during OnCloseDocument()