### PR TITLE
automatically set status to Currently Reading on progress update

### DIFF
--- a/hardcover/lib/constants/settings.lua
+++ b/hardcover/lib/constants/settings.lua
@@ -1,5 +1,6 @@
 local Settings = {
   ALWAYS_SYNC = "always_sync",
+  AUTO_STATUS_READING = "auto_status_reading",
   BOOKS = "books",
   COMPATIBILITY_MODE = "compatibility_mode",
   ENABLE_WIFI = "enable_wifi",

--- a/hardcover/lib/hardcover_settings.lua
+++ b/hardcover/lib/hardcover_settings.lua
@@ -194,4 +194,8 @@ function HardcoverSettings:compatibilityMode()
   return self.settings:readSetting(SETTING.COMPATIBILITY_MODE) == true
 end
 
+function HardcoverSettings:autoStatusReading()
+  return self.settings:readSetting(SETTING.AUTO_STATUS_READING) == true
+end
+
 return HardcoverSettings

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -603,6 +603,16 @@ function HardcoverMenu:getSettingsSubMenuItems()
       end,
     },
     {
+      text = "Automatically set status to Currently Reading",
+      checked_func = function()
+        return self.settings:readSetting(SETTING.AUTO_STATUS_READING) == true
+      end,
+      callback = function()
+        local setting = self.settings:readSetting(SETTING.AUTO_STATUS_READING) == true
+        self.settings:updateSetting(SETTING.AUTO_STATUS_READING, not setting)
+      end,
+    },
+    {
       text = "Enable wifi on demand",
       checked_func = function()
         return self.settings:readSetting(SETTING.ENABLE_WIFI) == true

--- a/main.lua
+++ b/main.lua
@@ -266,18 +266,33 @@ function HardcoverApp:_handlePageUpdate(filename, mapped_page, immediate, callba
     return
   end
 
-  if self.state.book_status.status_id ~= HARDCOVER.STATUS.READING then
-    return
-  end
-
-  local reads = self.state.book_status.user_book_reads
-  local current_read = reads and reads[#reads]
-  if not current_read then
-    return
-  end
-
-  local immediate_update = function()
+  local dominated_update = function()
     self.wifi:withWifi(function()
+      -- Auto-set status to Currently Reading if enabled and status allows it
+      if self.settings:autoStatusReading() then
+        local status_id = self.state.book_status.status_id
+        if status_id ~= HARDCOVER.STATUS.READING and
+           status_id ~= HARDCOVER.STATUS.FINISHED and
+           status_id ~= HARDCOVER.STATUS.DNF then
+          self.cache:updateBookStatus(filename, HARDCOVER.STATUS.READING)
+          if self.state.book_status.id then
+            UIManager:show(Notification:new {
+              text = _("Status updated to Currently Reading"),
+            })
+          end
+        end
+      end
+
+      if self.state.book_status.status_id ~= HARDCOVER.STATUS.READING then
+        return
+      end
+
+      local reads = self.state.book_status.user_book_reads
+      local current_read = reads and reads[#reads]
+      if not current_read then
+        return
+      end
+
       local result = Api:updatePage(current_read.id, current_read.edition_id, mapped_page, current_read.started_at)
       if result then
         self.state.book_status = result
@@ -289,11 +304,11 @@ function HardcoverApp:_handlePageUpdate(filename, mapped_page, immediate, callba
   end
 
   local trapped_update = function()
-    Trapper:wrap(immediate_update)
+    Trapper:wrap(dominated_update)
   end
 
   if immediate then
-    immediate_update()
+    dominated_update()
   else
     UIManager:scheduleIn(1, trapped_update)
   end


### PR DESCRIPTION
Adds a new global setting "Automatically set status to Currently Reading" that, when enabled, automatically updates book status to "Currently Reading" when progress is tracked.
- Only triggers if status is not already FINISHED or DNF
- Shows notification when status is changed
- Setting located in Settings submenu after "Always track progress by default"

## Changes
- `hardcover/lib/constants/settings.lua` — added `AUTO_STATUS_READING` constant
- `hardcover/lib/hardcover_settings.lua` — added `autoStatusReading()` helper
- `hardcover/lib/ui/hardcover_menu.lua` — added checkbox in settings menu
- `main.lua` — modified `_handlePageUpdate()` to auto-set status before syncing

> [!NOTE]
> This feature was developed with assistance from Claude Opus 4.5 using [opencode](https://github.com/opencode-ai/opencode).
> Link to the conversation: https://opncd.ai/share/gFNI4L6t
