### PR TITLE
Add Review feature: write and edit book reviews from KOReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.0 (2026-04-28)
+
+### Added
+
+* Added "Review" menu item under "Update status" to write, edit, or clear a book review on Hardcover. Editor accepts plain text with paragraph breaks; reviews with rich formatting (bold, italic, links) written on the Hardcover web app prompt a warning before editing here, since plain-text round-tripping flattens that formatting
+* Per-book review draft persistence — typed-but-unsaved review text survives accidental dismissal and KOReader restarts. Cleared on successful save or hold-to-clear
+
+### Fixes
+
+* Fix the rating-save error toast (was previously suppressed by a typo so the user saw nothing if a rating save failed)
+
 ## 0.4.0 (2026-04-26)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Selecting text to quote:
 After selecting document text in a linked document, choose `Hardcover quote` from the highlight menu to display the
 journal entry form, prefilled with the selected text and page.
 
+### Reviewing a book
+
+You can write a Hardcover review for a linked book from `Update status` → `Review`.
+
+The editor accepts plain text with paragraph breaks (separate paragraphs with a blank line). Tap **Save** to send the review to Hardcover; tap **Cancel** to dismiss.
+
+To clear an existing review, tap and hold the `Review` menu item and confirm.
+
+If you've previously written a review for this book on Hardcover with rich formatting (bold, italic, links, etc.), you'll be warned before opening the editor — saving from here will flatten the review to plain text.
+
+If you start writing a review and dismiss the dialog by mistake, your text is preserved as a draft and restored the next time you open the editor for the same book.
+
 ### Automatically track progress
 
 Automatic progress tracking is optional: book status and reading progress can instead be

--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ journal entry form, prefilled with the selected text and page.
 
 You can write a Hardcover review for a linked book from `Update status` → `Review`.
 
-The editor accepts plain text with paragraph breaks (separate paragraphs with a blank line). Tap **Save** to send the review to Hardcover; tap **Cancel** to dismiss.
-
-To clear an existing review, tap and hold the `Review` menu item and confirm.
+The editor accepts plain text with paragraph breaks (separate paragraphs with a blank line). Tap **Save** to send the review to Hardcover; tap **Cancel** to dismiss. Saving an empty review clears the review on Hardcover.
 
 If you've previously written a review for this book on Hardcover with rich formatting (bold, italic, links, etc.), you'll be warned before opening the editor — saving from here will flatten the review to plain text.
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -3,5 +3,5 @@ return {
   name = "hardcoverapp",
   fullname = _("Hardcover"),
   description = _([[Synchronize reading progress to Hardcover.app]]),
-  version = "0.4.0"
+  version = "0.5.0"
 }

--- a/hardcover/lib/hardcover_api.lua
+++ b/hardcover/lib/hardcover_api.lua
@@ -668,9 +668,17 @@ function HardcoverApi:updateReview(user_book_id, plain_text)
   end
 
   local result = self:query(query, { id = user_book_id, review = slate })
-  if result and result.update_user_book then
-    return result.update_user_book.user_book
+  if not (result and result.update_user_book) then
+    return nil
   end
+
+  local mutation = result.update_user_book
+  if mutation.error then
+    logger.warn("HardcoverApi:updateReview server error:", mutation.error)
+    return nil, mutation.error
+  end
+
+  return mutation.user_book
 end
 
 function HardcoverApi:removeRead(user_book_id)

--- a/hardcover/lib/hardcover_api.lua
+++ b/hardcover/lib/hardcover_api.lua
@@ -76,6 +76,7 @@ fragment UserBookParts on user_books {
   edition_id
   privacy_setting_id
   rating
+  review
   review_raw
   user_book_reads(order_by: {id: asc}) {
     id

--- a/hardcover/lib/hardcover_api.lua
+++ b/hardcover/lib/hardcover_api.lua
@@ -10,6 +10,7 @@ local NetworkManager = require("ui/network/manager")
 local socketutil = require("socketutil")
 
 local Book = require("hardcover/lib/book")
+local ReviewFormat = require("hardcover/lib/review_format")
 local VERSION = require("hardcover_version")
 
 local api_url = "https://api.hardcover.app/v1/graphql"
@@ -75,6 +76,7 @@ fragment UserBookParts on user_books {
   edition_id
   privacy_setting_id
   rating
+  review_raw
   user_book_reads(order_by: {id: asc}) {
     id
     started_at
@@ -642,6 +644,29 @@ function HardcoverApi:updateRating(user_book_id, rating)
   end
 
   local result = self:query(query, { id = user_book_id, rating = rating })
+  if result and result.update_user_book then
+    return result.update_user_book.user_book
+  end
+end
+
+function HardcoverApi:updateReview(user_book_id, plain_text)
+  local query = [[
+    mutation ($id: Int!, $review: jsonb) {
+      update_user_book(id: $id, object: { review_slate: $review }) {
+        error
+        user_book {
+          ...UserBookParts
+        }
+      }
+    }
+  ]] .. user_book_fragment
+
+  local slate = ReviewFormat.buildSlateDocument(plain_text)
+  if slate == nil then
+    slate = json.util.null
+  end
+
+  local result = self:query(query, { id = user_book_id, review = slate })
   if result and result.update_user_book then
     return result.update_user_book.user_book
   end

--- a/hardcover/lib/hardcover_settings.lua
+++ b/hardcover/lib/hardcover_settings.lua
@@ -202,4 +202,16 @@ function HardcoverSettings:menuConfirm()
   return self.settings:readSetting(SETTING.MENU_CONFIRMATION) == true
 end
 
+function HardcoverSettings:getReviewDraft(filename)
+  return self:readBookSetting(filename, "review_draft")
+end
+
+function HardcoverSettings:setReviewDraft(filename, text)
+  self:updateBookSetting(filename, { review_draft = text })
+end
+
+function HardcoverSettings:clearReviewDraft(filename)
+  self:updateBookSetting(filename, { _delete = { "review_draft" } })
+end
+
 return HardcoverSettings

--- a/hardcover/lib/review_format.lua
+++ b/hardcover/lib/review_format.lua
@@ -1,0 +1,40 @@
+local ReviewFormat = {}
+
+local function paragraph_block(text)
+  return {
+    data = {},
+    type = "paragraph",
+    object = "block",
+    children = { { text = text, object = "text" } }
+  }
+end
+
+function ReviewFormat.buildSlateDocument(plain_text)
+  if plain_text == nil then
+    return nil
+  end
+  if string.match(plain_text, "^%s*$") then
+    return nil
+  end
+
+  local children = {}
+  local last_end = 1
+  while true do
+    local start_idx, end_idx = string.find(plain_text, "\n\n", last_end, true)
+    if not start_idx then
+      table.insert(children, paragraph_block(string.sub(plain_text, last_end)))
+      break
+    end
+    table.insert(children, paragraph_block(string.sub(plain_text, last_end, start_idx - 1)))
+    last_end = end_idx + 1
+  end
+
+  return {
+    document = {
+      object = "document",
+      children = children
+    }
+  }
+end
+
+return ReviewFormat

--- a/hardcover/lib/review_format.lua
+++ b/hardcover/lib/review_format.lua
@@ -9,6 +9,10 @@ local function paragraph_block(text)
   }
 end
 
+local function has_non_whitespace(text)
+  return not string.match(text, "^%s*$")
+end
+
 function ReviewFormat.buildSlateDocument(plain_text)
   if plain_text == nil then
     return nil
@@ -22,10 +26,16 @@ function ReviewFormat.buildSlateDocument(plain_text)
   while true do
     local start_idx, end_idx = string.find(plain_text, "\n\n", last_end, true)
     if not start_idx then
-      table.insert(children, paragraph_block(string.sub(plain_text, last_end)))
+      local segment = string.sub(plain_text, last_end)
+      if has_non_whitespace(segment) then
+        table.insert(children, paragraph_block(segment))
+      end
       break
     end
-    table.insert(children, paragraph_block(string.sub(plain_text, last_end, start_idx - 1)))
+    local segment = string.sub(plain_text, last_end, start_idx - 1)
+    if has_non_whitespace(segment) then
+      table.insert(children, paragraph_block(segment))
+    end
     last_end = end_idx + 1
   end
 

--- a/hardcover/lib/review_format.lua
+++ b/hardcover/lib/review_format.lua
@@ -47,4 +47,19 @@ function ReviewFormat.buildSlateDocument(plain_text)
   }
 end
 
+function ReviewFormat.hasRichFormatting(html)
+  if html == nil or html == "" then
+    return false
+  end
+
+  -- Strip the markup that plain-text round-trips through Hardcover's renderer:
+  -- <p>, </p>, <br>, <br/>, <br />. If anything else with a `<` remains, it's rich.
+  local stripped = html
+  stripped = string.gsub(stripped, "<p>", "")
+  stripped = string.gsub(stripped, "</p>", "")
+  stripped = string.gsub(stripped, "<br%s*/?>", "")
+
+  return string.find(stripped, "<", 1, true) ~= nil
+end
+
 return ReviewFormat

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -524,17 +524,22 @@ function HardcoverMenu:getStatusSubMenuItems()
         local draft = self.settings:getReviewDraft(file)
 
         local initial_text
+        local restored_from_draft = false
         if draft and draft ~= saved_review then
           initial_text = draft
-          UIManager:show(InfoMessage:new {
-            text = _("Restored unsaved draft."),
-            timeout = 2,
-          })
+          restored_from_draft = true
         else
           initial_text = saved_review
         end
 
         local function openEditor()
+          if restored_from_draft then
+            UIManager:show(InfoMessage:new {
+              text = _("Restored unsaved draft."),
+              timeout = 2,
+            })
+          end
+
           local dialog
           dialog = InputDialog:new {
             title = _("Review"),

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -163,11 +163,19 @@ function HardcoverMenu:getSubMenuItems(book_view)
         self.cache:cacheUserBook()
 
         -- If wifi is off, prompt for it. Don't auto-disable — the user
-        -- is about to interact with menu items that need wifi.
+        -- is about to interact with menu items that need wifi. After
+        -- wifi comes on and the cache fills, walk the UI stack to find
+        -- the open submenu and refresh it so items reflect fresh state.
         if not NetworkMgr:isWifiOn() then
           self.wifi:wifiPrompt(function(wifi_enabled)
-            if wifi_enabled then
-              self.cache:cacheUserBook()
+            if not wifi_enabled then return end
+            self.cache:cacheUserBook()
+            for i = #UIManager._window_stack, 1, -1 do
+              local widget = UIManager._window_stack[i].widget
+              if widget and widget.updateItems and widget.item_table then
+                widget:updateItems()
+                break
+              end
             end
           end)
         end

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -12,6 +12,7 @@ local UIManager = require("ui/uimanager")
 
 local UpdateDoubleSpinWidget = require("hardcover/lib/ui/update_double_spin_widget")
 local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
 local SpinWidget = require("ui/widget/spinwidget")
 
 local Api = require("hardcover/lib/hardcover_api")
@@ -493,7 +494,7 @@ function HardcoverMenu:getStatusSubMenuItems()
               self.state.book_status = result
               menu_instance:updateItems()
             else
-              self.dialog_magager:showError("Rating could not be saved")
+              self.dialog_manager:showError("Rating could not be saved")
             end
           end
         }
@@ -505,6 +506,66 @@ function HardcoverMenu:getStatusSubMenuItems()
           self.state.book_status = result
           menu_instance:updateItems()
         end
+      end,
+      keep_menu_open = true,
+    },
+    {
+      text = _("Review"),
+      enabled_func = function()
+        return self.enabled and self.state.book_status.id ~= nil
+      end,
+      callback = function(menu_instance)
+        local user_book_id = self.state.book_status.id
+        local initial_text = self.state.book_status.review_raw or ""
+
+        local dialog
+        dialog = InputDialog:new {
+          title = _("Review"),
+          input = initial_text,
+          allow_newline = true,
+          buttons = {
+            {
+              {
+                text = _("Cancel"),
+                id = "close",
+                callback = function()
+                  UIManager:close(dialog)
+                end
+              },
+              {
+                text = _("Save"),
+                is_enter_default = true,
+                callback = function()
+                  local text = dialog:getInputText()
+                  local result = Api:updateReview(user_book_id, text)
+                  if result then
+                    self.state.book_status = result
+                    UIManager:close(dialog)
+                    menu_instance:updateItems()
+                  else
+                    self.dialog_manager:showError("Review could not be saved")
+                  end
+                end
+              }
+            }
+          }
+        }
+        UIManager:show(dialog)
+        dialog:onShowKeyboard()
+      end,
+      hold_callback = function(menu_instance)
+        self.dialog_manager:maybeConfirm({
+          text = "Clear book review?",
+          ok_callback = function()
+            local result = Api:updateReview(self.state.book_status.id, nil)
+            if result then
+              self.state.book_status = result
+              menu_instance:updateItems()
+            else
+              self.dialog_manager:showError("Review could not be cleared")
+            end
+          end
+        })
       end,
       keep_menu_open = true,
       separator = true

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -537,14 +537,22 @@ function HardcoverMenu:getStatusSubMenuItems()
                 is_enter_default = true,
                 callback = function()
                   local text = dialog:getInputText()
-                  local result = Api:updateReview(user_book_id, text)
-                  if result then
-                    self.state.book_status = result
-                    UIManager:close(dialog)
-                    menu_instance:updateItems()
-                  else
-                    self.dialog_manager:showError("Review could not be saved")
-                  end
+                  self.wifi:wifiPrompt(function(wifi_enabled)
+                    local result = Api:updateReview(user_book_id, text)
+                    if result then
+                      self.state.book_status = result
+                      UIManager:close(dialog)
+                      menu_instance:updateItems()
+                    else
+                      self.dialog_manager:showError("Review could not be saved")
+                    end
+
+                    if wifi_enabled then
+                      UIManager:nextTick(function()
+                        self.wifi:wifiDisablePrompt()
+                      end)
+                    end
+                  end)
                 end
               }
             }
@@ -557,13 +565,21 @@ function HardcoverMenu:getStatusSubMenuItems()
         self.dialog_manager:maybeConfirm({
           text = "Clear book review?",
           ok_callback = function()
-            local result = Api:updateReview(self.state.book_status.id, nil)
-            if result then
-              self.state.book_status = result
-              menu_instance:updateItems()
-            else
-              self.dialog_manager:showError("Review could not be cleared")
-            end
+            self.wifi:wifiPrompt(function(wifi_enabled)
+              local result = Api:updateReview(self.state.book_status.id, nil)
+              if result then
+                self.state.book_status = result
+                menu_instance:updateItems()
+              else
+                self.dialog_manager:showError("Review could not be cleared")
+              end
+
+              if wifi_enabled then
+                UIManager:nextTick(function()
+                  self.wifi:wifiDisablePrompt()
+                end)
+              end
+            end)
           end
         })
       end,

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -11,12 +11,14 @@ local Font = require("ui/font")
 local UIManager = require("ui/uimanager")
 
 local UpdateDoubleSpinWidget = require("hardcover/lib/ui/update_double_spin_widget")
+local ConfirmBox = require("ui/widget/confirmbox")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local SpinWidget = require("ui/widget/spinwidget")
 
 local Api = require("hardcover/lib/hardcover_api")
 local Github = require("hardcover/lib/github")
+local ReviewFormat = require("hardcover/lib/review_format")
 local User = require("hardcover/lib/user")
 local _t = require("hardcover/lib/table_util")
 
@@ -518,6 +520,7 @@ function HardcoverMenu:getStatusSubMenuItems()
         local file = self.ui.document.file
         local user_book_id = self.state.book_status.id
         local saved_review = self.state.book_status.review_raw or ""
+        local saved_review_html = self.state.book_status.review or ""
         local draft = self.settings:getReviewDraft(file)
 
         local initial_text
@@ -531,62 +534,72 @@ function HardcoverMenu:getStatusSubMenuItems()
           initial_text = saved_review
         end
 
-        local dialog
-        dialog = InputDialog:new {
-          title = _("Review"),
-          input = initial_text,
-          allow_newline = true,
-          close_callback = function()
-            -- Persist a draft on any close path (Cancel, tap-outside, back).
-            -- The successful-Save branch clears _text_modified before closing
-            -- to suppress this.
-            if dialog._text_modified then
-              local current = dialog:getInputText()
-              if current ~= saved_review then
-                self.settings:setReviewDraft(file, current)
+        local function openEditor()
+          local dialog
+          dialog = InputDialog:new {
+            title = _("Review"),
+            input = initial_text,
+            allow_newline = true,
+            close_callback = function()
+              if dialog._text_modified then
+                local current = dialog:getInputText()
+                if current ~= saved_review then
+                  self.settings:setReviewDraft(file, current)
+                end
               end
-            end
-          end,
-          buttons = {
-            {
+            end,
+            buttons = {
               {
-                text = _("Cancel"),
-                id = "close",
-                callback = function()
-                  UIManager:close(dialog)
-                end
-              },
-              {
-                text = _("Save"),
-                is_enter_default = true,
-                callback = function()
-                  local text = dialog:getInputText()
-                  self.wifi:wifiPrompt(function(wifi_enabled)
-                    local result = Api:updateReview(user_book_id, text)
-                    if result then
-                      self.settings:clearReviewDraft(file)
-                      self.state.book_status = result
-                      dialog._text_modified = false
-                      UIManager:close(dialog)
-                      menu_instance:updateItems()
-                    else
-                      self.settings:setReviewDraft(file, text)
-                      self.dialog_manager:showError("Review could not be saved")
-                    end
+                {
+                  text = _("Cancel"),
+                  id = "close",
+                  callback = function()
+                    UIManager:close(dialog)
+                  end
+                },
+                {
+                  text = _("Save"),
+                  is_enter_default = true,
+                  callback = function()
+                    local text = dialog:getInputText()
+                    self.wifi:wifiPrompt(function(wifi_enabled)
+                      local result = Api:updateReview(user_book_id, text)
+                      if result then
+                        self.settings:clearReviewDraft(file)
+                        self.state.book_status = result
+                        dialog._text_modified = false
+                        UIManager:close(dialog)
+                        menu_instance:updateItems()
+                      else
+                        self.settings:setReviewDraft(file, text)
+                        self.dialog_manager:showError("Review could not be saved")
+                      end
 
-                    if wifi_enabled then
-                      UIManager:nextTick(function()
-                        self.wifi:wifiDisablePrompt()
-                      end)
-                    end
-                  end)
-                end
+                      if wifi_enabled then
+                        UIManager:nextTick(function()
+                          self.wifi:wifiDisablePrompt()
+                        end)
+                      end
+                    end)
+                  end
+                }
               }
             }
           }
-        }
-        UIManager:show(dialog)
-        dialog:onShowKeyboard()
+          UIManager:show(dialog)
+          dialog:onShowKeyboard()
+        end
+
+        if ReviewFormat.hasRichFormatting(saved_review_html) then
+          UIManager:show(ConfirmBox:new {
+            text = _("This review contains formatting that will be lost if you save changes here. Edit anyway?"),
+            ok_text = _("Edit anyway"),
+            cancel_text = _("Cancel"),
+            ok_callback = openEditor,
+          })
+        else
+          openEditor()
+        end
       end,
       hold_callback = function(menu_instance)
         local file = self.ui.document.file

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -9,6 +9,8 @@ local T = require("ffi/util").template
 
 local Font = require("ui/font")
 local UIManager = require("ui/uimanager")
+local NetworkMgr = require("ui/network/manager")
+local Notification = require("ui/widget/notification")
 
 local UpdateDoubleSpinWidget = require("hardcover/lib/ui/update_double_spin_widget")
 local ConfirmBox = require("ui/widget/confirmbox")
@@ -157,14 +159,19 @@ function HardcoverMenu:getSubMenuItems(book_view)
         return self.settings:bookLinked()
       end,
       sub_item_table_func = function()
-        self.wifi:wifiPrompt(function(wifi_enabled)
-          self.cache:cacheUserBook()
-          if wifi_enabled then
-            UIManager:nextTick(function()
-              self.wifi:wifiDisablePrompt()
-            end)
-          end
-        end)
+        -- Try cache synchronously; succeeds if wifi is already on.
+        self.cache:cacheUserBook()
+
+        -- If wifi is off, prompt for it. Don't auto-disable — the user
+        -- is about to interact with menu items that need wifi.
+        if not NetworkMgr:isWifiOn() then
+          self.wifi:wifiPrompt(function(wifi_enabled)
+            if wifi_enabled then
+              self.cache:cacheUserBook()
+            end
+          end)
+        end
+
         return self:getStatusSubMenuItems()
       end,
       separator = true
@@ -561,6 +568,9 @@ function HardcoverMenu:getStatusSubMenuItems()
             title = _("Review"),
             input = initial_text,
             allow_newline = true,
+            fullscreen = true,
+            condensed = true,
+            add_scroll_buttons = true,
             buttons = {
               {
                 {
@@ -609,6 +619,9 @@ function HardcoverMenu:getStatusSubMenuItems()
                             self.state.book_status = result
                             UIManager:close(dialog)
                             menu_instance:updateItems()
+                            UIManager:show(Notification:new {
+                              text = _("Review saved to Hardcover"),
+                            })
                           end
                         else
                           self.settings:setReviewDraft(file, text)
@@ -657,6 +670,9 @@ function HardcoverMenu:getStatusSubMenuItems()
                   self.settings:clearReviewDraft(file)
                   self.state.book_status = result
                   menu_instance:updateItems()
+                  UIManager:show(Notification:new {
+                    text = _("Review cleared on Hardcover"),
+                  })
                 else
                   local message = err
                     and ("Review could not be cleared: " .. tostring(err))

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -515,14 +515,38 @@ function HardcoverMenu:getStatusSubMenuItems()
         return self.enabled and self.state.book_status.id ~= nil
       end,
       callback = function(menu_instance)
+        local file = self.ui.document.file
         local user_book_id = self.state.book_status.id
-        local initial_text = self.state.book_status.review_raw or ""
+        local saved_review = self.state.book_status.review_raw or ""
+        local draft = self.settings:getReviewDraft(file)
+
+        local initial_text
+        if draft and draft ~= saved_review then
+          initial_text = draft
+          UIManager:show(InfoMessage:new {
+            text = _("Restored unsaved draft."),
+            timeout = 2,
+          })
+        else
+          initial_text = saved_review
+        end
 
         local dialog
         dialog = InputDialog:new {
           title = _("Review"),
           input = initial_text,
           allow_newline = true,
+          close_callback = function()
+            -- Persist a draft on any close path (Cancel, tap-outside, back).
+            -- The successful-Save branch clears _text_modified before closing
+            -- to suppress this.
+            if dialog._text_modified then
+              local current = dialog:getInputText()
+              if current ~= saved_review then
+                self.settings:setReviewDraft(file, current)
+              end
+            end
+          end,
           buttons = {
             {
               {
@@ -540,10 +564,13 @@ function HardcoverMenu:getStatusSubMenuItems()
                   self.wifi:wifiPrompt(function(wifi_enabled)
                     local result = Api:updateReview(user_book_id, text)
                     if result then
+                      self.settings:clearReviewDraft(file)
                       self.state.book_status = result
+                      dialog._text_modified = false
                       UIManager:close(dialog)
                       menu_instance:updateItems()
                     else
+                      self.settings:setReviewDraft(file, text)
                       self.dialog_manager:showError("Review could not be saved")
                     end
 
@@ -562,15 +589,18 @@ function HardcoverMenu:getStatusSubMenuItems()
         dialog:onShowKeyboard()
       end,
       hold_callback = function(menu_instance)
+        local file = self.ui.document.file
         self.dialog_manager:maybeConfirm({
           text = "Clear book review?",
           ok_callback = function()
             self.wifi:wifiPrompt(function(wifi_enabled)
               local result = Api:updateReview(self.state.book_status.id, nil)
               if result then
+                self.settings:clearReviewDraft(file)
                 self.state.book_status = result
                 menu_instance:updateItems()
               else
+                -- Don't wipe the draft if the server clear didn't succeed.
                 self.dialog_manager:showError("Review could not be cleared")
               end
 

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -593,15 +593,29 @@ function HardcoverMenu:getStatusSubMenuItems()
                     local text = dialog:getInputText()
                     self.wifi:wifiPrompt(function(wifi_enabled)
                       Trapper:wrap(function()
-                        local result = Api:updateReview(user_book_id, text)
+                        local result, err = Api:updateReview(user_book_id, text)
                         if result then
-                          self.settings:clearReviewDraft(file)
-                          self.state.book_status = result
-                          UIManager:close(dialog)
-                          menu_instance:updateItems()
+                          -- Sanity check: did the server actually take the update?
+                          -- Compare ignoring trailing whitespace differences.
+                          local sent = (text or ""):gsub("%s+$", "")
+                          local got = (result.review_raw or ""):gsub("%s+$", "")
+                          if sent ~= got then
+                            logger.warn("HardcoverApi:updateReview accepted but review_raw doesn't match. sent="
+                              .. tostring(sent):sub(1, 80) .. " got=" .. tostring(got):sub(1, 80))
+                            self.settings:setReviewDraft(file, text)
+                            self.dialog_manager:showError("Review save did not apply on Hardcover. Draft preserved.")
+                          else
+                            self.settings:clearReviewDraft(file)
+                            self.state.book_status = result
+                            UIManager:close(dialog)
+                            menu_instance:updateItems()
+                          end
                         else
                           self.settings:setReviewDraft(file, text)
-                          self.dialog_manager:showError("Review could not be saved")
+                          local message = err
+                            and ("Review could not be saved: " .. tostring(err))
+                            or "Review could not be saved"
+                          self.dialog_manager:showError(message)
                         end
 
                         if wifi_enabled then
@@ -638,14 +652,16 @@ function HardcoverMenu:getStatusSubMenuItems()
           ok_callback = function()
             self.wifi:wifiPrompt(function(wifi_enabled)
               Trapper:wrap(function()
-                local result = Api:updateReview(self.state.book_status.id, nil)
+                local result, err = Api:updateReview(self.state.book_status.id, nil)
                 if result then
                   self.settings:clearReviewDraft(file)
                   self.state.book_status = result
                   menu_instance:updateItems()
                 else
-                  -- Don't wipe the draft if the server clear didn't succeed.
-                  self.dialog_manager:showError("Review could not be cleared")
+                  local message = err
+                    and ("Review could not be cleared: " .. tostring(err))
+                    or "Review could not be cleared"
+                  self.dialog_manager:showError(message)
                 end
 
                 if wifi_enabled then

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -676,38 +676,6 @@ function HardcoverMenu:getStatusSubMenuItems()
           openEditor()
         end
       end,
-      hold_callback = function(menu_instance)
-        local file = self.ui.document.file
-        self.dialog_manager:maybeConfirm({
-          text = "Clear book review?",
-          ok_callback = function()
-            self.wifi:wifiPrompt(function(wifi_enabled)
-              Trapper:wrap(function()
-                local result, err = Api:updateReview(self.state.book_status.id, nil)
-                if result then
-                  self.settings:clearReviewDraft(file)
-                  self.state.book_status = result
-                  menu_instance:updateItems()
-                  UIManager:show(Notification:new {
-                    text = _("Review cleared on Hardcover"),
-                  })
-                else
-                  local message = err
-                    and ("Review could not be cleared: " .. tostring(err))
-                    or "Review could not be cleared"
-                  self.dialog_manager:showError(message)
-                end
-
-                if wifi_enabled then
-                  UIManager:nextTick(function()
-                    self.wifi:wifiDisablePrompt()
-                  end)
-                end
-              end)
-            end)
-          end
-        })
-      end,
       keep_menu_open = true,
       separator = true
     },

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -14,7 +14,10 @@ local UpdateDoubleSpinWidget = require("hardcover/lib/ui/update_double_spin_widg
 local ConfirmBox = require("ui/widget/confirmbox")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
+local MultiConfirmBox = require("ui/widget/multiconfirmbox")
 local SpinWidget = require("ui/widget/spinwidget")
+
+local Trapper = require("ui/trapper")
 
 local Api = require("hardcover/lib/hardcover_api")
 local Github = require("hardcover/lib/github")
@@ -154,8 +157,14 @@ function HardcoverMenu:getSubMenuItems(book_view)
         return self.settings:bookLinked()
       end,
       sub_item_table_func = function()
-        self.cache:cacheUserBook()
-
+        self.wifi:wifiPrompt(function(wifi_enabled)
+          self.cache:cacheUserBook()
+          if wifi_enabled then
+            UIManager:nextTick(function()
+              self.wifi:wifiDisablePrompt()
+            end)
+          end
+        end)
         return self:getStatusSubMenuItems()
       end,
       separator = true
@@ -540,29 +549,41 @@ function HardcoverMenu:getStatusSubMenuItems()
             })
           end
 
-          local save_succeeded = false
-
           local dialog
+          local function dismiss_with_draft(text)
+            if text and text ~= saved_review then
+              self.settings:setReviewDraft(file, text)
+            end
+            UIManager:close(dialog)
+          end
+
           dialog = InputDialog:new {
             title = _("Review"),
             input = initial_text,
             allow_newline = true,
-            close_callback = function()
-              if save_succeeded then
-                return
-              end
-              local current = dialog:getInputText() or ""
-              if current ~= saved_review then
-                self.settings:setReviewDraft(file, current)
-              end
-            end,
             buttons = {
               {
                 {
                   text = _("Cancel"),
                   id = "close",
                   callback = function()
-                    UIManager:close(dialog)
+                    local current = dialog:getInputText() or ""
+                    if current == initial_text then
+                      UIManager:close(dialog)
+                      return
+                    end
+                    UIManager:show(MultiConfirmBox:new {
+                      text = _("You have unsaved changes."),
+                      cancel_text = _("Continue editing"),
+                      choice1_text = _("Discard"),
+                      choice1_callback = function()
+                        UIManager:close(dialog)
+                      end,
+                      choice2_text = _("Save draft"),
+                      choice2_callback = function()
+                        dismiss_with_draft(current)
+                      end,
+                    })
                   end
                 },
                 {
@@ -571,23 +592,24 @@ function HardcoverMenu:getStatusSubMenuItems()
                   callback = function()
                     local text = dialog:getInputText()
                     self.wifi:wifiPrompt(function(wifi_enabled)
-                      local result = Api:updateReview(user_book_id, text)
-                      if result then
-                        self.settings:clearReviewDraft(file)
-                        self.state.book_status = result
-                        save_succeeded = true
-                        UIManager:close(dialog)
-                        menu_instance:updateItems()
-                      else
-                        self.settings:setReviewDraft(file, text)
-                        self.dialog_manager:showError("Review could not be saved")
-                      end
+                      Trapper:wrap(function()
+                        local result = Api:updateReview(user_book_id, text)
+                        if result then
+                          self.settings:clearReviewDraft(file)
+                          self.state.book_status = result
+                          UIManager:close(dialog)
+                          menu_instance:updateItems()
+                        else
+                          self.settings:setReviewDraft(file, text)
+                          self.dialog_manager:showError("Review could not be saved")
+                        end
 
-                      if wifi_enabled then
-                        UIManager:nextTick(function()
-                          self.wifi:wifiDisablePrompt()
-                        end)
-                      end
+                        if wifi_enabled then
+                          UIManager:nextTick(function()
+                            self.wifi:wifiDisablePrompt()
+                          end)
+                        end
+                      end)
                     end)
                   end
                 }
@@ -615,21 +637,23 @@ function HardcoverMenu:getStatusSubMenuItems()
           text = "Clear book review?",
           ok_callback = function()
             self.wifi:wifiPrompt(function(wifi_enabled)
-              local result = Api:updateReview(self.state.book_status.id, nil)
-              if result then
-                self.settings:clearReviewDraft(file)
-                self.state.book_status = result
-                menu_instance:updateItems()
-              else
-                -- Don't wipe the draft if the server clear didn't succeed.
-                self.dialog_manager:showError("Review could not be cleared")
-              end
+              Trapper:wrap(function()
+                local result = Api:updateReview(self.state.book_status.id, nil)
+                if result then
+                  self.settings:clearReviewDraft(file)
+                  self.state.book_status = result
+                  menu_instance:updateItems()
+                else
+                  -- Don't wipe the draft if the server clear didn't succeed.
+                  self.dialog_manager:showError("Review could not be cleared")
+                end
 
-              if wifi_enabled then
-                UIManager:nextTick(function()
-                  self.wifi:wifiDisablePrompt()
-                end)
-              end
+                if wifi_enabled then
+                  UIManager:nextTick(function()
+                    self.wifi:wifiDisablePrompt()
+                  end)
+                end
+              end)
             end)
           end
         })

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -170,11 +170,21 @@ function HardcoverMenu:getSubMenuItems(book_view)
           self.wifi:wifiPrompt(function(wifi_enabled)
             if not wifi_enabled then return end
             self.cache:cacheUserBook()
+            -- Walk the UI stack for an open TouchMenu (item_table_stack is
+            -- the discriminator). It lives either directly on the stack or
+            -- wrapped in a menu_container (the ReaderMenu pattern, where
+            -- container[1] is the TouchMenu).
             for i = #UIManager._window_stack, 1, -1 do
               local widget = UIManager._window_stack[i].widget
-              if widget and widget.updateItems and widget.item_table then
-                widget:updateItems()
-                break
+              if widget then
+                if widget.updateItems and widget.item_table_stack then
+                  widget:updateItems()
+                  return
+                end
+                if widget[1] and widget[1].updateItems and widget[1].item_table_stack then
+                  widget[1]:updateItems()
+                  return
+                end
               end
             end
           end)

--- a/hardcover/lib/ui/hardcover_menu.lua
+++ b/hardcover/lib/ui/hardcover_menu.lua
@@ -540,17 +540,20 @@ function HardcoverMenu:getStatusSubMenuItems()
             })
           end
 
+          local save_succeeded = false
+
           local dialog
           dialog = InputDialog:new {
             title = _("Review"),
             input = initial_text,
             allow_newline = true,
             close_callback = function()
-              if dialog._text_modified then
-                local current = dialog:getInputText()
-                if current ~= saved_review then
-                  self.settings:setReviewDraft(file, current)
-                end
+              if save_succeeded then
+                return
+              end
+              local current = dialog:getInputText() or ""
+              if current ~= saved_review then
+                self.settings:setReviewDraft(file, current)
               end
             end,
             buttons = {
@@ -572,7 +575,7 @@ function HardcoverMenu:getStatusSubMenuItems()
                       if result then
                         self.settings:clearReviewDraft(file)
                         self.state.book_status = result
-                        dialog._text_modified = false
+                        save_succeeded = true
                         UIManager:close(dialog)
                         menu_instance:updateItems()
                       else

--- a/main.lua
+++ b/main.lua
@@ -147,6 +147,7 @@ function HardcoverApp:init()
     settings = self.settings,
     state = self.state,
     ui = self.ui,
+    wifi = self.wifi,
   }
 
   self:onDispatcherRegisterActions()

--- a/spec/lib/review_format_spec.lua
+++ b/spec/lib/review_format_spec.lua
@@ -1,0 +1,45 @@
+local ReviewFormat = require("hardcover/lib/review_format")
+
+describe("ReviewFormat", function()
+  describe("buildSlateDocument", function()
+    it("wraps a single paragraph in the legacy Slate document shape", function()
+      local result = ReviewFormat.buildSlateDocument("Hello world.")
+
+      assert.are.same({
+        document = {
+          object = "document",
+          children = {
+            {
+              data = {},
+              type = "paragraph",
+              object = "block",
+              children = {
+                { text = "Hello world.", object = "text" }
+              }
+            }
+          }
+        }
+      }, result)
+    end)
+
+    it("splits paragraphs on double newlines", function()
+      local result = ReviewFormat.buildSlateDocument("First paragraph.\n\nSecond paragraph.")
+
+      assert.are.equal(2, #result.document.children)
+      assert.are.equal("First paragraph.", result.document.children[1].children[1].text)
+      assert.are.equal("Second paragraph.", result.document.children[2].children[1].text)
+    end)
+
+    it("returns nil for empty input", function()
+      assert.is_nil(ReviewFormat.buildSlateDocument(""))
+    end)
+
+    it("returns nil for whitespace-only input", function()
+      assert.is_nil(ReviewFormat.buildSlateDocument("   \n\n  \t  "))
+    end)
+
+    it("returns nil for nil input", function()
+      assert.is_nil(ReviewFormat.buildSlateDocument(nil))
+    end)
+  end)
+end)

--- a/spec/lib/review_format_spec.lua
+++ b/spec/lib/review_format_spec.lua
@@ -41,5 +41,34 @@ describe("ReviewFormat", function()
     it("returns nil for nil input", function()
       assert.is_nil(ReviewFormat.buildSlateDocument(nil))
     end)
+
+    it("ignores leading double newlines", function()
+      local result = ReviewFormat.buildSlateDocument("\n\nActual text.")
+
+      assert.are.equal(1, #result.document.children)
+      assert.are.equal("Actual text.", result.document.children[1].children[1].text)
+    end)
+
+    it("ignores trailing double newlines", function()
+      local result = ReviewFormat.buildSlateDocument("Actual text.\n\n")
+
+      assert.are.equal(1, #result.document.children)
+      assert.are.equal("Actual text.", result.document.children[1].children[1].text)
+    end)
+
+    it("collapses multiple consecutive blank lines", function()
+      local result = ReviewFormat.buildSlateDocument("First.\n\n\n\nSecond.")
+
+      assert.are.equal(2, #result.document.children)
+      assert.are.equal("First.", result.document.children[1].children[1].text)
+      assert.are.equal("Second.", result.document.children[2].children[1].text)
+    end)
+
+    it("treats a single newline as part of the paragraph, not a separator", function()
+      local result = ReviewFormat.buildSlateDocument("Line one.\nLine two.")
+
+      assert.are.equal(1, #result.document.children)
+      assert.are.equal("Line one.\nLine two.", result.document.children[1].children[1].text)
+    end)
   end)
 end)

--- a/spec/lib/review_format_spec.lua
+++ b/spec/lib/review_format_spec.lua
@@ -71,4 +71,35 @@ describe("ReviewFormat", function()
       assert.are.equal("Line one.\nLine two.", result.document.children[1].children[1].text)
     end)
   end)
+
+  describe("hasRichFormatting", function()
+    it("returns false for a single plain paragraph", function()
+      assert.is_false(ReviewFormat.hasRichFormatting("<p>Just plain text.</p>"))
+    end)
+
+    it("returns false for multiple plain paragraphs with line breaks", function()
+      assert.is_false(ReviewFormat.hasRichFormatting("<p>One.</p><p>Two.<br>still two.</p>"))
+    end)
+
+    it("returns false for nil or empty input", function()
+      assert.is_false(ReviewFormat.hasRichFormatting(nil))
+      assert.is_false(ReviewFormat.hasRichFormatting(""))
+    end)
+
+    it("returns false for the empty-paragraph artifact <p><br></p>", function()
+      assert.is_false(ReviewFormat.hasRichFormatting("<p><br></p>"))
+    end)
+
+    it("returns true when there is bold markup", function()
+      assert.is_true(ReviewFormat.hasRichFormatting("<p>Some <strong>bold</strong> text.</p>"))
+    end)
+
+    it("returns true when there is a link", function()
+      assert.is_true(ReviewFormat.hasRichFormatting('<p>See <a href="x">this</a>.</p>'))
+    end)
+
+    it("returns true when there is italic markup", function()
+      assert.is_true(ReviewFormat.hasRichFormatting("<p>Some <em>italic</em> text.</p>"))
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

Adds a `Review` menu item under `Update status` that lets the user write, edit, and clear a Hardcover book review without leaving KOReader.

- Editor opens fullscreen with paragraph-aware plain-text input, prefilled with the book's existing `review_raw` so edits are cleanly round-trippable.
- Sends a Slate 0.47 document via the `update_user_book` mutation's `review_slate` field. The server derives `review`, `review_raw`, `review_length`, and `has_review` from that.
- Empty save clears the review on Hardcover.
- Per-book draft persistence: typed-but-unsaved text survives accidental dismiss and KOReader restarts. A `MultiConfirmBox` ("Continue editing / Discard / Save draft") fires when text differs from the initial buffer.
- Wifi handling reuses the existing `AutoWifi:wifiPrompt` plumbing, matching `Suggest a book`. Opening `Update status` now also prompts for wifi when off (and refreshes the submenu once the cache fills).
- Save flow is wrapped in `Trapper:wrap` so the existing `dismissableRunInSubprocess` loading dialog actually renders.
- API errors are surfaced — both the `update_user_book.error` field and a sanity check that compares the text we sent against the returned `review_raw` (catches silent server no-ops).
- Bumps version to \`0.5.0\`. Fixes a pre-existing typo (\`dialog_magager\`) that suppressed the rating-save error toast.

I tested this on my Pocketbook and it works really well. Happy with it so I figured I'd share.

## Implementation notes

- The Hardcover GraphQL \`update_user_book\` input type doesn't accept \`review_raw\`/\`review\`/\`review_html\` — only \`review_slate\` (jsonb). Probed live to determine the exact legacy Slate 0.47 immutable document shape the server expects.
- New module \`hardcover/lib/review_format.lua\` is a pure helper — no KOReader runtime deps, fully busted-tested. The settings/api/menu changes follow the repo's existing convention of manual testing for network/UI code.
- The \`Update status\` submenu auto-refreshes after a wifi-on cache fill by walking \`UIManager._window_stack\` for the open \`TouchMenu\` (which ReaderMenu wraps in a \`menu_container\`). Slightly invasive but matches patterns elsewhere in KOReader plugins.

## Caveats

- 19 commits — happy to squash if preferred.
- The PR includes the version bump to 0.5.0; revert/adjust to taste.