### PR TITLE
Add percentage to position metadata

### DIFF
--- a/hardcover/lib/ui/dialog_manager.lua
+++ b/hardcover/lib/ui/dialog_manager.lua
@@ -45,13 +45,17 @@ local function mapJournalData(data)
   end
 
   if data.page then
-    result.metadata = {
-      position = {
-        type = "pages",
-        value = data.page,
-        possible = data.pages
-      }
+    local position = {
+      type = "pages",
+      value = data.page,
+      possible = data.pages
     }
+
+    if type(data.pages) == "number" and data.pages > 0 then
+      position.percent = (data.page / data.pages) * 100
+    end
+
+    result.metadata = { position = position }
   end
 
   return result


### PR DESCRIPTION
I hope you don't mind the PR. I've been running this edit locally for a while as I find percentage to be a more reliable progress indicator when syncing quotes from multiple environments - I sync via KoReader on Kindle and Readest on iOS - both report wildly different page counts. When importing hardcover quotes into Obsidian, it's been much easier to sort them based on percentage.

Touches 1 file, adds 4 lines.